### PR TITLE
MIP#10c14 SP2 MyCrypto Light Feed

### DIFF
--- a/MIP10/MIP10c14-Subproposals/MIP10c14-SP2-MyCrypto.md
+++ b/MIP10/MIP10c14-Subproposals/MIP10c14-SP2-MyCrypto.md
@@ -1,4 +1,4 @@
-# MIP10c14: Subproposal to Appoint Light Feed
+# MIP10c14: Subproposal to Appoint MyCrypto as a Light Feed for the Maker Oracles
 
 ## Preamble
 ```

--- a/MIP10/MIP10c14-Subproposals/MIP10c14-SP2-MyCrypto.md
+++ b/MIP10/MIP10c14-Subproposals/MIP10c14-SP2-MyCrypto.md
@@ -1,0 +1,58 @@
+# MIP10c14: Subproposal to Appoint Light Feed
+
+## Preamble
+```
+MIP10c14-SP#: 
+Author(s): Harry Denley
+Contributors: Jordan Spence, Mia Alexander
+Type: Process Component
+Status: Proposed
+Date Proposed: 2020-07-13
+Date Ratified: <yyyy-mm-dd>
+``` 
+
+## Specification
+
+### Organization
+- Name: MyCrypto
+- Website: https://mycrypto.com
+- Github: https://github.com/MyCryptoHQ
+- Number of Employees: 15-20
+- Email: jordan@mycrypto.com
+- Incorporated: 2018
+- Domiciled: Delaware C Corp
+- When was the organization founded? 2018
+- Who are the major investors in your organization?: Polychain, ShapeShift, BoostVC, Ausum Ventures, Mick Hagen, Chance Du, Lily Liu, Albert Ni
+- How much funding has the organization raised either privately or through a token sale?: $4 Million
+- Please provide public references for the above where possible: https://medium.com/mycrypto/our-first-funding-round-9acf048c9d05
+
+### Introduction
+- Motivation for running a Light Feed
+
+MyCrypto has provided infrastructure for the Ethereum blockchain for many years, and are one of the few teams to do so. We love the Maker team, and 
+our engineers are experienced, reliable, and eager to learn more and contribute to Maker’s goals in this arena!
+
+### Community
+- What has your organization contributed to the crypto community?
+
+MyCrypto provides a client-side, open-source interface to the Ethereum blockchain that allows users to access and manage their ETH & 
+ERC20 tokens, and interact with smart contracts directly, among many other things. We also provide infrastructure with an Ethereum node, alongside 
+Infura and Etherscan.
+
+- Successful products, services, tools, libraries, thought-leadership
+
+MyCrypto.com (mycrypto.com)
+MyCrypto Desktop App (download.mycrypto.com)
+MyCrypto Beta (beta.mycrypto.com)
+MyCrypto Overflow (overflow.mycrypto.com)
+CryptoScamDB (cryptoscamdb.org)
+MyCrypto Medium (medium.com/mycrypto)
+
+- How will the Maker Community benefit from your inclusion as a Light Feed?
+
+MyCrypto has a solid track record of providing valuable products, resources, and infrastructure to the community. Many don’t realize it but 
+we’ve been running our own infrastructure since 2017. This runs in our blood! We believe that we’d be a valuable addition to the others 
+who are participating.
+
+### Changelog
+- List of updates


### PR DESCRIPTION
Adds a MIP10c14: Subproposal to Appoint MyCrypto as a Light Feed for the Maker Oracles

- MIP10c14-SP2: Appoint MyCrypto as a Light Feed for the Maker Oracles 

- Author(s): Harry Denley (@409H)

- Contributors: Jordan Spence (@jspence425), Mia Alexander (@miagx)

- Type: Process Component

- Status: Proposed

- Date Proposed: 2020-07-13

- Date Ratified: <yyyy-mm-dd>